### PR TITLE
Sync with HorlogeSkynet/archey4

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ Below, some further explanations of each option available :
 		"char_before_unit": " ",
 		// Display temperature values in Fahrenheit instead of Celsius.
 		"use_fahrenheit": false
+	},
+	"timeout": {
+		// Some values you can adjust if the default ones look undersized for your system (seconds)
 	}
 }
 ```

--- a/archey
+++ b/archey
@@ -399,6 +399,10 @@ class Configuration():
             'temperature': {
                 'char_before_unit': ' ',
                 'use_fahrenheit': False
+            },
+            'timeout': {
+                'ipv4_detection': 1,
+                'ipv6_detection': 1
             }
         }
 
@@ -861,13 +865,15 @@ class WAN_IP:
                 ipv6_value = check_output([
                     'dig', '+short', '-6', 'aaaa', 'myip.opendns.com',
                     '@resolver1.ipv6-sandbox.opendns.com'
-                    ], timeout=0.5, stderr=DEVNULL).decode().rstrip()
+                    ], timeout=config.get('timeout')['ipv6_detection'],
+                    stderr=DEVNULL).decode().rstrip()
 
             except (FileNotFoundError, TimeoutExpired):
                 try:
                     ipv6_value = check_output([
                         'wget', '-qO-', 'https://v6.ident.me/'
-                        ], timeout=1).decode()
+                        ], timeout=config.get('timeout')['ipv6_detection']
+                        ).decode()
 
                 except (CalledProcessError, TimeoutExpired):
                     # It looks like this user doesn't have any IPv6 address...
@@ -881,13 +887,15 @@ class WAN_IP:
         try:
             ipv4_value = check_output([
                 'dig', '+short', 'myip.opendns.com', '@resolver1.opendns.com'
-                ], timeout=0.5, stderr=DEVNULL).decode().rstrip()
+                ], timeout=config.get('timeout')['ipv4_detection'],
+                stderr=DEVNULL).decode().rstrip()
 
         except (FileNotFoundError, TimeoutExpired):
             try:
                 ipv4_value = check_output([
                     'wget', '-qO-', 'https://v4.ident.me/'
-                    ], timeout=1).decode()
+                    ], timeout=config.get('timeout')['ipv4_detection']
+                    ).decode()
 
             except (CalledProcessError, TimeoutExpired):
                 # This user looks not connected to Internet...

--- a/config.json
+++ b/config.json
@@ -34,5 +34,9 @@
 	"temperature": {
 		"char_before_unit": " ",
 		"use_fahrenheit": false
+	},
+	"timeout": {
+		"ipv4_detection": 1,
+		"ipv6_detection": 1
 	}
 }


### PR DESCRIPTION
* Adds config.get('timeout')['ipv6'] and config.get('timeout')['ipv4'] to archey

* Add timeout option with separate timers for ipv6 and ipv4.

* Renames option name + PEP8

* Adds new options to documentation

* Adds new timeout option to default values (in case of standalone execution)

* Sets default timeouts to 1 second instead of 5

<!--- Provide a general summary of your changes in the title above -->


## Description
<!--- Describe your changes in detail -->


## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->


## How has this been tested ?
<!--- Include details of your testing environment here -->


## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [ ] My change looks good ;
- [ ] I have updated the _README.md_ file accordingly ;
- [ ] I agree that my code may be modified in the future ;
- [ ] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
